### PR TITLE
We still need EBI repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,15 @@
 
     </dependencies>
 
+    <repositories>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Hi @ypriverol ,

Although most are in the pride-core pom, we still need to add the ECI repo. Otherwise, where do we download the pride-core.pom?

Bests