### PR TITLE
Do not print id to console

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/tools/mzxml_parser/MzXMLFile.java
+++ b/src/main/java/uk/ac/ebi/pride/tools/mzxml_parser/MzXMLFile.java
@@ -865,7 +865,7 @@ public class MzXMLFile implements JMzReader {
 
     @Override
     public Spectrum getSpectrumById(String id) throws JMzReaderException {
-        System.out.println(id);
+        // System.out.println(id);
         // get the scan object
         try {
             Scan scan = getScanByStringNum(id);


### PR DESCRIPTION
Printing id to console is annoying since it is a library that is supposed used by other software,