### PR TITLE
Delete unused dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,36 +47,14 @@
 
 	<properties>
         <!-- Logging capabilities -->
-        <uk.ac.ebi.pride.architectural-pride-logging.version>1.0.0</uk.ac.ebi.pride.architectural-pride-logging.version>
-        <uk.ac.ebi.pride.architectural-pride-tdd.version>1.0.3</uk.ac.ebi.pride.architectural-pride-tdd.version>
         <uk.ac.ebi.jmzml-jmzml.version>1.7.9</uk.ac.ebi.jmzml-jmzml.version>
         <uk.ac.ebi.pride.jaxb-pride-jaxb.version>1.0.20</uk.ac.ebi.pride.jaxb-pride-jaxb.version>
         <!-- Dependencies -->
-        <uk.ac.ebi.pride.architectural-pride-xml-handling.version>1.0.1</uk.ac.ebi.pride.architectural-pride-xml-handling.version>
         <org.jvnet.jaxb2.maven2-maven-jaxb2-plugin.version>0.6.3</org.jvnet.jaxb2.maven2-maven-jaxb2-plugin.version>
 
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>uk.ac.ebi.pride.architectural</groupId>
-            <artifactId>pride-logging</artifactId>
-            <type>pom</type>
-            <version>${uk.ac.ebi.pride.architectural-pride-logging.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>uk.ac.ebi.pride.architectural</groupId>
-            <artifactId>pride-tdd</artifactId>
-            <type>pom</type>
-            <version>${uk.ac.ebi.pride.architectural-pride-tdd.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>uk.ac.ebi.pride.architectural</groupId>
-            <artifactId>pride-xml-handling</artifactId>
-            <type>pom</type>
-            <version>${uk.ac.ebi.pride.architectural-pride-xml-handling.version}</version>
-        </dependency>
         <dependency>
             <groupId>uk.ac.ebi.jmzml</groupId>
             <artifactId>jmzml</artifactId>


### PR DESCRIPTION
These packages are not used, Furthermore, `pride-logging` and `pride-xml-handling` don't have jar in the EBI repo.